### PR TITLE
OP가 플러그인 종료후 봇테러 날리는일 방지

### DIFF
--- a/src/main/java/cloud/swiftnode/kspam/KSpam.java
+++ b/src/main/java/cloud/swiftnode/kspam/KSpam.java
@@ -23,7 +23,7 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
-
+    
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/src/main/java/cloud/swiftnode/kspam/KSpam.java
+++ b/src/main/java/cloud/swiftnode/kspam/KSpam.java
@@ -27,7 +27,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-;/**
+/**
  * Created by Junhyeong Lim on 2017-01-10.
  */
 public class KSpam extends JavaPlugin {
@@ -64,7 +64,7 @@ public class KSpam extends JavaPlugin {
         saveConfig();
         new CacheSaveProcessor().process();
         boolean sws = getConfig().getBoolean("shutdownwithserver", false);
-        if (sws) {
+        if (!sws) {
         break;
         }
         //OP가 플러그인 종료후 봇테러 날리는일 방지

--- a/src/main/java/cloud/swiftnode/kspam/KSpam.java
+++ b/src/main/java/cloud/swiftnode/kspam/KSpam.java
@@ -63,12 +63,13 @@ public class KSpam extends JavaPlugin {
     public void onDisable() {
         saveConfig();
         new CacheSaveProcessor().process();
-        sws = getConfig().getBoolean("shutdownwithserver", false);
+        boolean sws = getConfig().getBoolean("shutdownwithserver", false);
         if (sws) {
+        break;
+        }
         //OP가 플러그인 종료후 봇테러 날리는일 방지
         System.out.println("경고! K-SPAM 플러그인이 종료되었습니다. config.yml 정책에 의해 서버와 함께 종료됩니다.");
         Bukkit.shutdown();
-        }
     }
 
     @Override

--- a/src/main/java/cloud/swiftnode/kspam/KSpam.java
+++ b/src/main/java/cloud/swiftnode/kspam/KSpam.java
@@ -27,7 +27,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-/**
+;/**
  * Created by Junhyeong Lim on 2017-01-10.
  */
 public class KSpam extends JavaPlugin {
@@ -63,7 +63,7 @@ public class KSpam extends JavaPlugin {
     public void onDisable() {
         saveConfig();
         new CacheSaveProcessor().process();
-        getConfig().getBoolean("shutdownwithserver", false)
+        getConfig().getBoolean("shutdownwithserver", false);
         if (config.getBoolean("shutdownwithserver")) {
         //OP가 플러그인 종료후 봇테러 날리는일 방지
         System.out.println("경고! K-SPAM 플러그인이 종료되었습니다. config.yml 정책에 의해 서버와 함께 종료됩니다.");

--- a/src/main/java/cloud/swiftnode/kspam/KSpam.java
+++ b/src/main/java/cloud/swiftnode/kspam/KSpam.java
@@ -63,6 +63,9 @@ public class KSpam extends JavaPlugin {
     public void onDisable() {
         saveConfig();
         new CacheSaveProcessor().process();
+        //OP가 플러그인 종료후 봇테러 날리는일 방지
+        System.out.println("경고! K-SPAM 플러그인이 종료되었습니다. 서버와 함께 종료됩니다.");
+        Bukkit.shutdown();
     }
 
     @Override

--- a/src/main/java/cloud/swiftnode/kspam/KSpam.java
+++ b/src/main/java/cloud/swiftnode/kspam/KSpam.java
@@ -57,15 +57,18 @@ public class KSpam extends JavaPlugin {
         }, 20L, getConfig().getInt(Config.GC_PERIOD, 6) * 3600);
         Static.consoleMsg(Lang.INTRO.builder()
                 .single(Lang.Key.KSPAM_VERSION, Static.getVersion()));
+        config.addDefault("플러그인_종료시_서버끄기", false);
     }
 
     @Override
     public void onDisable() {
         saveConfig();
         new CacheSaveProcessor().process();
+        if (config.getBoolean("플러그인_종료시_서버끄기")) {
         //OP가 플러그인 종료후 봇테러 날리는일 방지
-        System.out.println("경고! K-SPAM 플러그인이 종료되었습니다. 서버와 함께 종료됩니다.");
+        System.out.println("경고! K-SPAM 플러그인이 종료되었습니다. config.yml 정책에 의해 서버와 함께 종료됩니다.");
         Bukkit.shutdown();
+        }
     }
 
     @Override

--- a/src/main/java/cloud/swiftnode/kspam/KSpam.java
+++ b/src/main/java/cloud/swiftnode/kspam/KSpam.java
@@ -63,8 +63,7 @@ public class KSpam extends JavaPlugin {
     public void onDisable() {
         saveConfig();
         new CacheSaveProcessor().process();
-        boolean sws = getConfig().getBoolean("shutdownwithserver", false);
-        if (sws) {
+        if (getConfig().getBoolean("shutdownwithserver", true)) {
             //OP가 플러그인 종료후 봇테러 날리는일 방지
             System.out.println("경고! K-SPAM 플러그인이 종료되었습니다. config.yml 정책에 의해 서버와 함께 종료됩니다.");
             Bukkit.shutdown();

--- a/src/main/java/cloud/swiftnode/kspam/KSpam.java
+++ b/src/main/java/cloud/swiftnode/kspam/KSpam.java
@@ -63,8 +63,8 @@ public class KSpam extends JavaPlugin {
     public void onDisable() {
         saveConfig();
         new CacheSaveProcessor().process();
-        getConfig().getBoolean("shutdownwithserver", false);
-        if (config.getBoolean("shutdownwithserver")) {
+        sws = getConfig().getBoolean("shutdownwithserver", false);
+        if (sws) {
         //OP가 플러그인 종료후 봇테러 날리는일 방지
         System.out.println("경고! K-SPAM 플러그인이 종료되었습니다. config.yml 정책에 의해 서버와 함께 종료됩니다.");
         Bukkit.shutdown();

--- a/src/main/java/cloud/swiftnode/kspam/KSpam.java
+++ b/src/main/java/cloud/swiftnode/kspam/KSpam.java
@@ -57,14 +57,14 @@ public class KSpam extends JavaPlugin {
         }, 20L, getConfig().getInt(Config.GC_PERIOD, 6) * 3600);
         Static.consoleMsg(Lang.INTRO.builder()
                 .single(Lang.Key.KSPAM_VERSION, Static.getVersion()));
-        config.addDefault("플러그인_종료시_서버끄기", false);
     }
 
     @Override
     public void onDisable() {
         saveConfig();
         new CacheSaveProcessor().process();
-        if (config.getBoolean("플러그인_종료시_서버끄기")) {
+        getConfig().getBoolean("shutdownwithserver", false)
+        if (config.getBoolean("shutdownwithserver")) {
         //OP가 플러그인 종료후 봇테러 날리는일 방지
         System.out.println("경고! K-SPAM 플러그인이 종료되었습니다. config.yml 정책에 의해 서버와 함께 종료됩니다.");
         Bukkit.shutdown();

--- a/src/main/java/cloud/swiftnode/kspam/KSpam.java
+++ b/src/main/java/cloud/swiftnode/kspam/KSpam.java
@@ -64,12 +64,11 @@ public class KSpam extends JavaPlugin {
         saveConfig();
         new CacheSaveProcessor().process();
         boolean sws = getConfig().getBoolean("shutdownwithserver", false);
-        if (!sws) {
-        break;
+        if (sws) {
+            //OP가 플러그인 종료후 봇테러 날리는일 방지
+            System.out.println("경고! K-SPAM 플러그인이 종료되었습니다. config.yml 정책에 의해 서버와 함께 종료됩니다.");
+            Bukkit.shutdown();
         }
-        //OP가 플러그인 종료후 봇테러 날리는일 방지
-        System.out.println("경고! K-SPAM 플러그인이 종료되었습니다. config.yml 정책에 의해 서버와 함께 종료됩니다.");
-        Bukkit.shutdown();
     }
 
     @Override


### PR DESCRIPTION
[1차] 서버 내 일부 부패한 관리자가 플러그인을 일부러 정지시키고 봇테러를 시전하는 케이스를 방지하기 위해 플러그인이 종료될경우 서버와 함께 종료되도록 설계하였습니다.